### PR TITLE
Pushing to anaconda 

### DIFF
--- a/.github/workflows/conda_dev.yml
+++ b/.github/workflows/conda_dev.yml
@@ -3,7 +3,7 @@ name: conda build
 on:
   push:
     branches:
-      - develop
+      - dev
 
 jobs:
   build-linux:

--- a/conda/env.yaml
+++ b/conda/env.yaml
@@ -17,4 +17,4 @@ dependencies:
   - pytest
   - coverage
   - ipython
-  - symudev
+  - symuvia=1.0.0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
         - setuptools
     host:
         - python
-        - setuptools   
+        - setuptools
     run:
         - numpy>=1.16
         - lxml>=4.3.3
@@ -32,10 +32,10 @@ requirements:
         - pytest
         - coverage
         - ipython
-        - symudev
+        - symuvia=1.0.0
 
 test:
-    imports: 
+    imports:
         - symupy
 
 about:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ CLASSIFIERS = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8"    
+    "Programming Language :: Python :: 3.8"
 ]
 
 with open("README.md", "r", encoding="UTF8") as f:
@@ -31,10 +31,6 @@ requirements = [
     "scipy>=1.4.1",
     "click>=7.0",
     "python-decouple>=3.3",
-]
-
-setup_requirements = [
-    "pytest-runner",
 ]
 
 test_requirements = [
@@ -63,8 +59,8 @@ setup(
     long_description_content_type="text/markdown",
     author="Andres Ladino",
     author_email="aladinoster@gmail.com",
-    maintainer="Andres Ladino", 
-    maintainer_email="aladinoster@gmail.com", 
+    maintainer="Andres Ladino",
+    maintainer_email="aladinoster@gmail.com",
     url="https://github.com/symuvia/symupy",
     download_url="https://github.com/symuvia/symupy",
     packages=find_packages(include=["symupy","symupy.*"]),
@@ -75,7 +71,6 @@ setup(
     install_requires=requirements,
     extra_require={"dev": dev_requirements},
     python_requires=">=3.7",
-    setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
     zip_safe=False,


### PR DESCRIPTION
This is to change the following behavior: 

```
conda create -n testsymupy -c licit-lab -c conda-forge symupy
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: | 
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed

PackagesNotFoundError: The following packages are not available from current channels:

  - symudev

Current channels:

  - https://conda.anaconda.org/licit-lab/osx-64
  - https://conda.anaconda.org/licit-lab/noarch
  - https://conda.anaconda.org/conda-forge/osx-64
  - https://conda.anaconda.org/conda-forge/noarch
  - https://repo.anaconda.com/pkgs/main/osx-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/osx-64
  - https://repo.anaconda.com/pkgs/r/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.
```