### PR TITLE
Adds the `AlterRoute` command within symupy

### DIFF
--- a/symupy/runtime/api/connector.py
+++ b/symupy/runtime/api/connector.py
@@ -400,7 +400,7 @@ class Simulator(Configurator, RuntimeDevice):
             new_route (str): string contained links separated by spaces with the path to be taken by the vehicle
 
         Returns:
-            int: 	Value containing one of the following values 
+            int: 	Value containing one of the following values
 
                 ===========  =================================
                 **Value**    **Description**
@@ -412,9 +412,9 @@ class Simulator(Configurator, RuntimeDevice):
                 -4            A link of the new route not in network
                 -5            New route is unattainable links are not connected
                 -6            New route destination is different from original
-                -7            New route cannot be reached by the vehicle     
+                -7            New route cannot be reached by the vehicle
                 ===========  =================================
-       
+
         """
         return self.__library.SymAlterRouteEx(vehid, new_route.encode("UTF8"))
 
@@ -684,7 +684,7 @@ class Simulator(Configurator, RuntimeDevice):
         self.__library.SymApplyControlZonesEx(-1)
         return self.dctidzone
 
-    def __enter__(self) -> None:
+    def __enter__(self):
         """
         This method initializes the usage of the ``Simulator`` class as a context manager.
 

--- a/symupy/runtime/api/connector.py
+++ b/symupy/runtime/api/connector.py
@@ -392,6 +392,32 @@ class Simulator(Configurator, RuntimeDevice):
         self.request_answer()
         return dr_state
 
+    def drive_vehicle_new_route(self, vehid: int, new_route: str) -> int:
+        """Modifies the current path of a vehicle by stablishing the new route
+
+        Args:
+            vehid (int): vehicle id
+            new_route (str): string contained links separated by spaces with the path to be taken by the vehicle
+
+        Returns:
+            int: 	Value containing one of the following values 
+
+                ===========  =================================
+                **Value**    **Description**
+                -----------  ---------------------------------
+                0             The function is successfully executed
+                -1            No network loaded
+                -2            The vehicle doesn't exist
+                -3            The new route is empty
+                -4            A link of the new route not in network
+                -5            New route is unattainable links are not connected
+                -6            New route destination is different from original
+                -7            New route cannot be reached by the vehicle     
+                ===========  =================================
+       
+        """
+        return self.__library.SymAlterRouteEx(vehid, new_route.encode("UTF8"))
+
     def drive_vehicle_with_control(
         self, vehcontrol, vehid: int, destination: str = None, lane: str = 1
     ):

--- a/symupy/runtime/api/connector.py
+++ b/symupy/runtime/api/connector.py
@@ -429,7 +429,9 @@ class Simulator(Configurator, RuntimeDevice):
     def init_symbol_states(self):
         """Initializes symbols before call of a runtime for access in memory"""
 
+
         # Total network information
+        self.__library.SymGetListofVehicleIdsEx.restype = c_char_p
         self.__library.SymGetTotalTravelTimeEx.restype = c_double
         self.__library.SymGetTotalTravelDistanceEx.restype = c_double
 

--- a/symupy/runtime/api/connector.py
+++ b/symupy/runtime/api/connector.py
@@ -607,7 +607,7 @@ class Simulator(Configurator, RuntimeDevice):
                     )
                 )
                 .decode("UTF8")
-                .split(" ")
+                .split(" ")[:-1]
             )
         return tuple()
 

--- a/symupy/runtime/api/connector.py
+++ b/symupy/runtime/api/connector.py
@@ -1,5 +1,5 @@
-""" 
-    This module details the implementation of a ``Simulator`` object in charge of handling the connection between the traffic simulator and this interface. The connection with the traffic simulator is handled by an object called ``Connector`` which establishes a messaging protocol with the traffic simulator. 
+"""
+    This module details the implementation of a ``Simulator`` object in charge of handling the connection between the traffic simulator and this interface. The connection with the traffic simulator is handled by an object called ``Connector`` which establishes a messaging protocol with the traffic simulator.
 
     Example:
         To use the ``Simulator`` declare in a string the ``path`` to the simulator ::
@@ -10,11 +10,11 @@
 
     Other parameters can also be send to the simulator in order to provide other configurations:
 
-    Example: 
+    Example:
         To send make increase the *buffer size* to a specific size:
-            
+
             >>> simulator = Simulator(bufferSize = 1000000)
-        
+
         To increase change the flag that traces the flow:
 
             >>> simulator = Simulator(trace_flow = True)
@@ -590,6 +590,27 @@ class Simulator(Configurator, RuntimeDevice):
                 spd.append(10)  # minimum speed?
         return tuple(spd)
 
+    def get_vehicle_inside_area(self, sensors_mfd: list = []):
+        """Obtains the set of vehicles inside a list
+
+        Args:
+            sensors_mfd (list, optional): Sensor name. Defaults to [].
+
+        Returns:
+            [type]: [description]
+        """
+        if isinstance(sensors_mfd, str):
+            return tuple(
+                (
+                    self.__library.SymGetListofVehicleIdsEx(
+                        sensors_mfd.encode("UTF8")
+                    )
+                )
+                .decode("UTF8")
+                .split(" ")
+            )
+        return tuple()
+
     def add_control_probability_zone_mfd(
         self, access_probability: dict, minimum_distance: dict
     ):
@@ -688,6 +709,7 @@ class Simulator(Configurator, RuntimeDevice):
         """
         self.load_symuvia()
         self.load_network()
+        self.__library.SymGetListofVehicleIdsEx.restype = c_char_p
         self.next_state(True)
 
     def __performInitialize(self) -> None:

--- a/symupy/runtime/logic/sorted_frozen_set.py
+++ b/symupy/runtime/logic/sorted_frozen_set.py
@@ -28,7 +28,7 @@ class SortedFrozenSet(Sequence, Set):
     """
 
     def __init__(self, items=None):
-        self._items = tuple(
+        self._items = list(
             sorted(
                 set(items) if (items is not None) else set(),
                 key=lambda x: x.vehid,

--- a/symupy/utils/configurator.py
+++ b/symupy/utils/configurator.py
@@ -12,6 +12,7 @@
 from ctypes import create_string_buffer, c_bool, c_char
 from dataclasses import dataclass
 import click
+from symupy.utils.screen import log_verify
 
 # ============================================================================
 # INTERNAL IMPORTS
@@ -96,6 +97,13 @@ class Configurator:
         click.echo("Configurator: Initialization")
         for key, value in kwargs.items():
             setattr(self, key, value)
+        try:
+            if kwargs["library_path"] != DEFAULT_PATH_SYMUFLOW:
+                log_verify("Using user defined library path: ", kwargs["library_path"],)
+        except KeyError:
+            log_verify("Using default defined library path")
+        finally:
+            return
 
     def __repr__(self):
         data_dct = ", ".join(f"{k}={v}" for k, v in self.__dict__.items())

--- a/symupy/utils/constants.py
+++ b/symupy/utils/constants.py
@@ -48,6 +48,7 @@ from collections import defaultdict
 # =============================================================================
 
 from symupy.utils.exceptions import SymupyError, SymupyWarning
+from symupy.utils.screen import log_success,log_warning
 from symupy import __version__
 
 # =============================================================================
@@ -105,12 +106,13 @@ for path in find_path(PATHS_2_SEARCH):
 
 
 try:
-    print(f"Default path: {DEFAULT_PATH_SYMUFLOW}")
+    log_success(f"Default path: {DEFAULT_PATH_SYMUFLOW}")
 except NameError:
     DEFAULT_PATH_SYMUFLOW = ""
+    log_warning("Setting `DEFAULT_PATH_SYMUFLOW` to an empty string")
     SymupyWarning("No Simulator could be defined")
     print(f"Default path: {DEFAULT_PATH_SYMUFLOW}")
-    
+
 
 
 

--- a/symupy/utils/parser.py
+++ b/symupy/utils/parser.py
@@ -249,3 +249,12 @@ class SimulatorRequest(Publisher):
         neighpos = self.filter_vehicle_property("distance", *neigh)
 
         return tuple(nbh for nbh, npos in zip(neigh, neighpos) if npos < vehpos)
+
+    def get_vehicle_in_link(self) -> dict:
+        """Get a map of vehicle ids and their correspnding link.
+
+        Returns:
+            map (dict):
+                zone - ids of vehicles
+        """
+        return {str(i["vehid"]): i["link"] for i in self.get_vehicle_data()}


### PR DESCRIPTION
This PR has as an intention to add a new symupy command for the added functionality on https://github.com/licit-lab/Open-SymuVia/commit/8c41ebe79fa3320f00ebd14c0e14db1872b0dede

Status: 
- [x] Functionality created 
- [x] Tests missing

To test please refer to the example: https://github.com/licit-lab/symupy-examples/blob/main/4-crosssing_by_steps.py

Instructions for reproducibility: https://github.com/licit-lab/symupy-examples/blob/main/README.md

**Note**: Change the path towards the corresponding local symuflow path. The last version of `symuflow` on anaconda does not expose methods to reroute or get vehicle properties.